### PR TITLE
Fix uninitialized value crashing patrace sometimes.

### DIFF
--- a/patrace/src/tracer/egltrace.cpp
+++ b/patrace/src/tracer/egltrace.cpp
@@ -965,7 +965,7 @@ void after_eglCreateWindowSurface(EGLDisplay dpy, EGLConfig config, EGLSurface s
 
 void after_eglCreateContext(EGLContext ctx, EGLDisplay dpy, EGLConfig config, const EGLint * attrib_list)
 {
-    EGLint configId;
+    EGLint configId = 0;
     _eglQueryContext(dpy, ctx, EGL_CONFIG_ID, &configId);
     int profile = GetGLESVersion(attrib_list);
 


### PR DESCRIPTION
_eglQueryContext could return false and configId is a random value.
Then patrace crashes at "configIdToConfigAttribsMap.at(configId)"

Signed-off-by: Lepton Wu <ytht.net@gmail.com>