### PR TITLE
cmake: Make fakedriver optional

### DIFF
--- a/patrace/project/cmake/CMakeLists.txt
+++ b/patrace/project/cmake/CMakeLists.txt
@@ -182,7 +182,9 @@ if (NOT FF_ONLY)
 
     if (${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND NOT WINDOWSYSTEM MATCHES "udriver")
         add_subdirectory(egltrace)
-        add_subdirectory(fakedriver)
+        if (NOT DISABLE_FAKEDRIVER)
+            add_subdirectory(fakedriver)
+        endif ()
     endif ()
 endif ()
 


### PR DESCRIPTION
The fakedriver libs that are created by default for Linux require special handling for a build tool like Yocto in order to avoid install conflicts with the real libs.

Avoid such special handling by making the usage of fakedriver optional. The user will provide real libs in this case.