### PR TITLE
Fix cmake >3.5 syntax rule compatiable issue

### DIFF
--- a/patrace/project/cmake/fakedriver/CMakeLists.txt
+++ b/patrace/project/cmake/fakedriver/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(
 add_library(EGL SHARED
 	${SRC_FAKEDRIVER_EGL}
 )
-add_dependencies(EGL ${SRC_ROOT}/fakedriver/egl/auto.cpp)
+add_dependencies(EGL egl_auto_src_generation)
 
 target_link_libraries (EGL
     dl
@@ -16,7 +16,7 @@ set_target_properties(EGL PROPERTIES LINK_FLAGS "-z max-page-size=16384")
 add_library(GLESv1_CM SHARED
 	${SRC_FAKEDRIVER_GLES1}
 )
-add_dependencies(GLESv1_CM ${SRC_ROOT}/fakedriver/gles1/auto.cpp)
+add_dependencies(GLESv1_CM gles1_auto_src_generation)
 
 target_link_libraries (GLESv1_CM
     dl
@@ -26,7 +26,7 @@ set_target_properties(GLESv1_CM PROPERTIES LINK_FLAGS "-z max-page-size=16384")
 add_library(GLESv2 SHARED
 	${SRC_FAKEDRIVER_GLES2_GLES3}
 )
-add_dependencies(GLESv2 ${SRC_ROOT}/fakedriver/gles2/auto.cpp)
+add_dependencies(GLESv2 gles2_auto_src_generation)
 
 target_link_libraries (GLESv2
     dl

--- a/patrace/project/cmake/fakedriver/src.cmake
+++ b/patrace/project/cmake/fakedriver/src.cmake
@@ -1,12 +1,32 @@
 add_custom_command (
     OUTPUT ${SRC_ROOT}/fakedriver/egl/auto.cpp
-        ${SRC_ROOT}/fakedriver/gles1/auto.cpp
-        ${SRC_ROOT}/fakedriver/gles2/auto.cpp
     COMMAND ${PYTHON_EXECUTABLE} ${SRC_ROOT}/fakedriver/autogencode.py
     DEPENDS
+        ${SRC_FAKEDRIVER_EGL}
         ${SRC_ROOT}/fakedriver/autogencode.py
     WORKING_DIRECTORY ${SRC_ROOT}/fakedriver
 )
+add_custom_target(egl_auto_src_generation DEPENDS ${SRC_ROOT}/fakedriver/egl/auto.cpp)
+
+add_custom_command (
+    OUTPUT ${SRC_ROOT}/fakedriver/gles1/auto.cpp
+    COMMAND ${PYTHON_EXECUTABLE} ${SRC_ROOT}/fakedriver/autogencode.py
+    DEPENDS
+        ${SRC_FAKEDRIVER_GLES1}
+        ${SRC_ROOT}/fakedriver/autogencode.py
+    WORKING_DIRECTORY ${SRC_ROOT}/fakedriver
+)
+add_custom_target(gles1_auto_src_generation DEPENDS ${SRC_ROOT}/fakedriver/gles1/auto.cpp)
+
+add_custom_command (
+    OUTPUT ${SRC_ROOT}/fakedriver/gles2/auto.cpp
+    COMMAND ${PYTHON_EXECUTABLE} ${SRC_ROOT}/fakedriver/autogencode.py
+    DEPENDS
+        ${SRC_FAKEDRIVER_GLES2_GLES3}
+        ${SRC_ROOT}/fakedriver/autogencode.py
+    WORKING_DIRECTORY ${SRC_ROOT}/fakedriver
+)
+add_custom_target(gles2_auto_src_generation DEPENDS ${SRC_ROOT}/fakedriver/gles2/auto.cpp)
 
 set(SRC_FAKEDRIVER_EGL
     ${SRC_ROOT}/fakedriver/common.cpp

--- a/patrace/project/cmake/fastforward/CMakeLists.txt
+++ b/patrace/project/cmake/fastforward/CMakeLists.txt
@@ -58,12 +58,18 @@ target_link_libraries (fastforward
     jsoncpp
     hwcpipe
 )
-add_dependencies(fastforward
+
+set(FASTFORWARD_DEPENDENCIES
     retrace_gles_auto_src_generation
     eglproc_auto_src_generation
-    call_parser_src_generation
     glxml_header
 )
+if(TARGET call_parser_src_generation)
+    list(APPEND FASTFORWARD_DEPENDENCIES call_parser_src_generation)
+endif()
+
+add_dependencies(fastforward ${FASTFORWARD_DEPENDENCIES})
+
 set_target_properties(fastforward PROPERTIES LINK_FLAGS "-pthread -z max-page-size=16384" COMPILE_FLAGS "-pthread")
 install(TARGETS fastforward
     RUNTIME DESTINATION bin)


### PR DESCRIPTION
call_parser.cpp may not exist in source_root so the target fastforward need add a condition.
GCC15 requires cmake version >3.5, Explicitly create target instead of use one add_custom_command generate multiple files output have more compatible and stable.